### PR TITLE
Remove forward slash from links in important callout on homepage.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,10 @@
 ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced on at the [Build developer conference](https://blogs.microsoft.com/on-the-issues/?p=63211), ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption](https://en.wikipedia.org/wiki/Homomorphic_encryption) to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted. 
 
 !!! important
-    First time to ElectionGuard? Check out our [Getting Started](/Getting_Started/) or our [Guide](/guide/overview).
+    First time to ElectionGuard? Check out our [Getting Started](Getting_Started/) or our [Guide](guide/overview).
 
 ## Open-Source
+
 This library and all linked ElectionGuard projects, are licensed under the MIT license. There is no fee for using ElectionGuard.
 
 ## Security Issues Reporting


### PR DESCRIPTION
Fixes #35 

### Description
Updates URLS for links within the "Important" callout on the homepage to be relative instead of absolute.

### Testing
Using Docker, spin up an nginx container to mimic hosting the site at https://microsoft.github.io/electionguard/:
1. Build the project: `mkdocs build`
2. Change directory to the generated output folder (`site`): `cd site`
3. Launch nginx container: `docker run -p 8000:80 -v $(pwd):/usr/share/nginx/html/electionguard nginx`
4. Browse to http://localhost:8000/electionguard/
5. Links to "Getting Started" and "Guide" should be `http://localhost:8000/electionguard/Getting_Started/` and `http://localhost:8000/electionguard/guide/overview` respectively.