### PR TITLE
🐛  Resolve relative link issues with MkDocs

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -1,17 +1,17 @@
 # Getting Started
 
-There are many places to start start in ElectionGuard. If you're looking to develop see below, if you just want to research see the [guide](/guide/Overview/). 
+There are many places to start start in ElectionGuard. If you're looking to develop see below, if you just want to research see the [guide](guide/Overview.md). 
 
 ## Latest
 
 These are the latest projects from ElectionGuard. If you're looking to contribute, these are the best places to start.
 
-[`electionguard-python`](/guide/Core_Component/#python)
+[`electionguard-python`](guide/Core_Component.md#python)
 
-[`electionguard-web-api`](/guide/Implementations)
+[`electionguard-web-api`](guide/Implementations.md)
 
 ## Language
 
 Pick your language of preference:
 
-[![](images/python-language.png)](/guide/Core_Component/#python)[![](images/c++-language.png)](/guide/Core_Component/#c++) [![](images/c-language.png)](/guide/Core_Component/#c_1) [![](images/c-sharp-language.png)](/guide/Core_Component/#c_2) 
+[![](images/python-language.png)](guide/Core_Component.md#python)[![](images/c++-language.png)](guide/Core_Component.md#c++) [![](images/c-language.png)](guide/Core_Component.md#c_1) [![](images/c-sharp-language.png)](guide/Core_Component.md#c_2) 

--- a/docs/guide/Overview.md
+++ b/docs/guide/Overview.md
@@ -1,7 +1,7 @@
 
 ## SDK
 
-The [ElectionGuard software development kit (SDK)](/guide/Core_Component/) contains two major parts. The core component for developing with ElectionGuard and reference implementations that interact with core component or provide a peek into the pieces required for the election process. 
+The [ElectionGuard software development kit (SDK)](Core_Component.md) contains two major parts. The core component for developing with ElectionGuard and reference implementations that interact with core component or provide a peek into the pieces required for the election process. 
 
 ## Specifications
 These documents contains the fundamental specifications, documentation, architecture, and mathematical/cryptographic proofs that underpin ElectionGuard. If you're looking to understand the system better, or want to know how to integrate the various components, there is a lot of valuable information contained here.
@@ -9,7 +9,7 @@ These documents contains the fundamental specifications, documentation, architec
 ### v 1.0.0
 
 !!! important 
-    This version is coming soon. Check out [`electionguard-python`]() for a working example.
+    This version is coming soon. Check out [`electionguard-python`](https://github.com/microsoft/electionguard-python) for a working example.
 
 :fontawesome-regular-file: Specification
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
 ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced on at the [Build developer conference](https://blogs.microsoft.com/on-the-issues/?p=63211), ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption](https://en.wikipedia.org/wiki/Homomorphic_encryption) to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted. 
 
 !!! important
-    First time to ElectionGuard? Check out our [Getting Started](/Getting_Started/) or our [Guide](/guide/overview).
+    First time to ElectionGuard? Check out our [Getting Started](Getting_Started.md) or our [Guide](guide/Overview.md).
 
 ## Open-Source
 This library and all linked ElectionGuard projects, are licensed under the MIT license. There is no fee for using ElectionGuard.


### PR DESCRIPTION
### Issue

Fixes #35 

### Description
mkdocs require use of .md for links to fully work when deployed despite working locally.
Paths without .md will work locally but can be problematic when deployed to GitHub Pages.
This resolves all outstanding path issues. 

https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages

### Testing
Run a local deploy `make serve`

