### PR TITLE
Fixes Issue #51: Add a discussion link to the website and to the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Help defend democracy and **[contribute to the project][]**.
 [Code of Conduct]: CODE_OF_CONDUCT.md
 [Contribute to the project]: CONTRIBUTING.md
 
-We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions regarding the specifications there.
+We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
 
 ## ❓ Questions
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Help defend democracy and **[contribute to the project][]**.
 [Code of Conduct]: CODE_OF_CONDUCT.md
 [Contribute to the project]: CONTRIBUTING.md
 
+We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions regarding the specifications there.
+
 ## ❓ Questions
 
 ElectionGuard would love for you to ask questions out in the open using Github Issues. If you really want to email the ElectionGuard team, reach out at electionguard@microsoft.com.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Help defend democracy and **[contribute to the project][]**.
 
 [Contribute to the project]: https://github.com/microsoft/electionguard/blob/main/CONTRIBUTING.md
 
-We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions regarding the specifications there.
+We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
 
 ## Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,8 @@ Help defend democracy and **[contribute to the project][]**.
 
 [Contribute to the project]: https://github.com/microsoft/electionguard/blob/main/CONTRIBUTING.md
 
+We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions regarding the specifications there.
+
 ## Questions
 
 ElectionGuard would love for you to ask questions out in the open using Github Issues. If you really want to email the ElectionGuard team, reach out at [electionguard@microsoft.com](mailto:electionguard@microsoft.com).


### PR DESCRIPTION
### Issue
Add a discussion link to the website and to the ReadMe

Fixes #51  

### Description
As request in the original issue, I have added the link to the discussions page https://github.com/microsoft/electionguard/discussions in both ```README.md``` and ```index.md```.

I have also made sure I follow the original request well:
- [x] Add a link in the Contributing section of the Readme.md
- [x] Add a link in the Contributing section of the index.md
- [x] Friendly wording to encourage people to asks questions and make suggestions

### Checklist
🚨Please review the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.

- [ ] 🤔 **CONSIDER** adding a unit test if your PR resolves an issue.
- [x] ✅ **DO** check open PR's to avoid duplicates.
- [x] ✅ **DO** keep pull requests small so they can be easily reviewed.
- [ ] ✅ **DO** build locally before pushing.
- [x] ✅ **DO** make sure tests pass.
- [x] ✅ **DO** make sure any new changes are documented.
- [x] ✅ **DO** make sure not to introduce any compiler warnings.
- [ ] ❌**AVOID** breaking the continuous integration build.
- [ ] ❌**AVOID** making significant changes to the overall architecture.

💔Thank you!