### PR TITLE
Use reference style links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Microsoft Defending Democracy Program: ElectionGuard][1]](http://microsoft.github.io/electionguard/)
+[![Microsoft Defending Democracy Program: ElectionGuard][election-guard-banner]](http://microsoft.github.io/electionguard/)
 
-[![license][2]](LICENSE)
+[![license][license-image]](LICENSE)
 
-ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced at the [Build developer conference][3], ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption][4] to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted.
+ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced at the [Build developer conference][build-developer-conference], ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption][homomoprhic-encryption] to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted.
 
 ## ❤️ Open-Source
 
@@ -10,42 +10,42 @@ This library and all linked ElectionGuard projects, are licensed under the MIT l
 
 ## 🚀 Getting Started
 
-ElectionGuard is always improving. To keep up with the latest, check our **[official site on GitHub Pages][5]** and our [roadmap][6]. For those looking to get started, we recommend the following repositories.
+ElectionGuard is always improving. To keep up with the latest, check our **[official site on GitHub Pages][election-guard-official-page]** and our [roadmap][election-guard-road-map]. For those looking to get started, we recommend the following repositories.
 
 ### Documentation
 
-This repository is a living document to help everyone interact with ElectionGuard. The [official ElectionGuard site][5] is built using the `/docs` folder and [mkdocs][7] with [mkdocs-material][8]. Ensure you have the python 3.8 or newer installed and run `make` to install the dependencies and start the site.
+This repository is a living document to help everyone interact with ElectionGuard. The [official ElectionGuard site][election-guard-official-page] is built using the `/docs` folder and [mkdocs][mkdocs-official-site] with [mkdocs-material][material-mkdocs]. Ensure you have the python 3.8 or newer installed and run `make` to install the dependencies and start the site.
 
 ### Python
 
 A core component of ElectionGuard implemented in python which includes ballot encryption, decryption, key generation, and tallying.
 
-[📁 Source][9] |
-[📦 Package][10] |
-[📝 Documentation][11]
+[📁 Source][election-guard-python-source] |
+[📦 Package][election-guard-python-package] |
+[📝 Documentation][election-guard-python-documentation]
 
 ### C ++
 
 A subset of the ElectionGuard SDK implemented in C++ to support ballot encryption.
 
-[📁 Source][12] |
-[📦 Package][13] |
-[📝 Documentation][14]]
+[📁 Source][election-guard-cpp-source-code] |
+[📦 Package][election-guard-cpp-package] |
+[📝 Documentation][election-guard-cpp-documentation]
 
 ### Web API
 
 A Web API that wraps the python package to perform ballot encryption, casting, spoiling, and tallying.
 
-[📁 Source][15] | 
-[🐳 Docker][16] | 
-[📄 Documentation][17]
+[📁 Source][election-guard-web-api-source] | 
+[🐳 Docker][election-guard-web-api-docker] | 
+[📄 Documentation][election-guard-web-api-documentation]
 
 ### User Interface
 
 Monorepo in React & Typescript consisting of an api client, components, and apps to demonstrate examples of user interface.
 
-[📁 Source][18] |
-[📄 Documentation][19]
+[📁 Source][election-guard-ui-source] |
+[📄 Documentation][election-guard-ui-documentation]
 
 ## 🛡 Security Issues Reporting
 
@@ -58,7 +58,7 @@ Help defend democracy and **[contribute to the project][]**.
 [code of conduct]: CODE_OF_CONDUCT.md
 [contribute to the project]: CONTRIBUTING.md
 
-We welcome discussions on our [discussions page][20], feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
+We welcome discussions on our [discussions page][election-guard-discussions], feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
 
 ## ❓ Questions
 
@@ -68,35 +68,35 @@ ElectionGuard would love for you to ask questions out in the open using Github I
 
 A huge thank you to those who helped to contribute to this project so far, including:
 
-- Josh Benaloh (whose [PhD thesis][21] was the genesis of much of this work)
-- [InfernoRed Technology][22]
-- [VotingWorks][23]
-- [Center for Civic Design][24]
-- [Oxide Design][25]
+- Josh Benaloh (whose [PhD thesis][verifiable-search-ballot-elections-paper] was the genesis of much of this work)
+- [InfernoRed Technology][infernored]
+- [VotingWorks][voting-works]
+- [Center for Civic Design][center-for-civic-design]
+- [Oxide Design][oxide-design]
 - Many teams within Microsoft
 
-[1]: docs/images/electionguard-banner.svg "Election Guard banner SVG"
-[2]: https://img.shields.io/github/license/microsoft/electionguard "Election Guard license image"
-[3]: https://blogs.microsoft.com/on-the-issues/?p=63211 "Protecting democratic elections through secure, verifiable voting"
-[4]: https://en.wikipedia.org/wiki/Homomorphic_encryption "Homomorphic encryption"
-[5]: https://microsoft.github.io/electionguard "Official Election Guard site on Github Pages"
-[6]: https://microsoft.github.io/electionguard/Roadmap "Election GUard road map"
-[7]: https://www.mkdocs.org/ "MkDocs official website"
-[8]: https://squidfunk.github.io/mkdocs-material/ "Material for MkDocs"
-[9]: https://github.com/microsoft/electionguard-python "Election Guard Python source code"
-[10]: https://pypi.org/project/electionguard/ "Election Guard Python package"
-[11]: https://microsoft.github.io/electionguard-python/ "Election Guard Python documentation"
-[12]: https://github.com/microsoft/electionguard-cpp/ "Election Guard C++ source code"
-[13]: https://www.nuget.org/packages/ElectionGuard.Encryption/ "Election Guard C++ package"
-[14]: https://github.com/microsoft/electionguard-cpp#readme "Election Guard C++ documentation"
-[15]: https://github.com/microsoft/electionguard-api-python "Election Guard Web API source code"
-[16]: https://hub.docker.com/r/electionguard/electionguard-web-api "Election Guard Web API Docker"
-[17]: https://microsoft.github.io/electionguard-api-python/ "Election Guard Web API documentation"
-[18]: https://github.com/microsoft/electionguard-ui "Election Guard UI source code"
-[19]: https://github.com/microsoft/electionguard-ui#readme "Election Guard UI documentation"
-[20]: https://github.com/microsoft/electionguard/discussions "Election Guard Discussions page"
-[21]: https://www.microsoft.com/en-us/research/publication/verifiable-secret-ballot-elections/ "Verifiable Secret-Ballot Elections - Microsoft Research, Josh Benaloh"
-[22]: https://infernored.com/ "InfernoRed"
-[23]: https://voting.works/ "Voting works - Elections you can trust"
-[24]: https://civicdesign.org/ "Center for civic design"
-[25]: https://oxidedesign.com/ "Oxide Design"
+[election-guard-banner]: docs/images/electionguard-banner.svg "Election Guard banner SVG"
+[license-image]: https://img.shields.io/github/license/microsoft/electionguard "Election Guard license image"
+[build-developer-conference]: https://blogs.microsoft.com/on-the-issues/?p=63211 "Protecting democratic elections through secure, verifiable voting"
+[homomoprhic-encryptio]: https://en.wikipedia.org/wiki/Homomorphic_encryption "Homomorphic encryption"
+[election-guard-official-page]: https://microsoft.github.io/electionguard "Official Election Guard site on Github Pages"
+[election-guard-road-map]: https://microsoft.github.io/electionguard/Roadmap "Election Guard road map"
+[mkdocs-official-site]: https://www.mkdocs.org/ "MkDocs official website"
+[material-mkdocs]: https://squidfunk.github.io/mkdocs-material/ "Material for MkDocs"
+[election-guard-python-source]: https://github.com/microsoft/electionguard-python "Election Guard Python source code"
+[election-guard-python-package]: https://pypi.org/project/electionguard/ "Election Guard Python package"
+[election-guard-python-documentation]: https://microsoft.github.io/electionguard-python/ "Election Guard Python documentation"
+[election-guard-cpp-source-code]: https://github.com/microsoft/electionguard-cpp/ "Election Guard C++ source code"
+[election-guard-cpp-package]: https://www.nuget.org/packages/ElectionGuard.Encryption/ "Election Guard C++ package"
+[election-guard-cpp-documentation]: https://github.com/microsoft/electionguard-cpp#readme "Election Guard C++ documentation"
+[election-guard-web-api-source]: https://github.com/microsoft/electionguard-api-python "Election Guard Web API source code"
+[election-guard-web-api-docker]: https://hub.docker.com/r/electionguard/electionguard-web-api "Election Guard Web API Docker"
+[election-guard-web-api-documentation]: https://microsoft.github.io/electionguard-api-python/ "Election Guard Web API documentation"
+[election-guard-ui-source]: https://github.com/microsoft/electionguard-ui "Election Guard UI source code"
+[election-guard-ui-documentation]: https://github.com/microsoft/electionguard-ui#readme "Election Guard UI documentation"
+[election-guard-discussions]: https://github.com/microsoft/electionguard/discussions "Election Guard Discussions page"
+[verifiable-search-ballot-elections-paper]: https://www.microsoft.com/en-us/research/publication/verifiable-secret-ballot-elections/ "Verifiable Secret-Ballot Elections - Microsoft Research, Josh Benaloh"
+[infernored]: https://infernored.com/ "InfernoRed"
+[voting-works]: https://voting.works/ "Voting works - Elections you can trust"
+[center-for-civic-design]: https://civicdesign.org/ "Center for Civic Design"
+[oxide-design]: https://oxidedesign.com/ "Oxide Design"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![Microsoft Defending Democracy Program: ElectionGuard](docs/images/electionguard-banner.svg)](http://microsoft.github.io/electionguard/)
+[![Microsoft Defending Democracy Program: ElectionGuard][1]](http://microsoft.github.io/electionguard/)
 
-[![license](https://img.shields.io/github/license/microsoft/electionguard)](LICENSE)
+[![license][2]](LICENSE)
 
-ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced on at the [Build developer conference](https://blogs.microsoft.com/on-the-issues/?p=63211), ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption](https://en.wikipedia.org/wiki/Homomorphic_encryption) to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted.
+ElectionGuard is an **open source** software development kit (SDK) that makes voting more secure, transparent and accessible. Announced at the [Build developer conference][3], ElectionGuard enables end-to-end verification of elections as well as support the publication of results from ballot comparison audits. The ElectionGuard SDK leverages [homomorphic encryption][4] to ensure that votes recorded by electronic systems of any type remain encrypted, secure, and secret. Results can be published online or made available to third-party organizations for secure validation, and allow individual voters to confirm their votes were correctly counted.
 
 ## ❤️ Open-Source
 
@@ -10,39 +10,42 @@ This library and all linked ElectionGuard projects, are licensed under the MIT l
 
 ## 🚀 Getting Started
 
-ElectionGuard is always improving. To keep up with the latest, check our **[official site on GitHub Pages](https://microsoft.github.io/electionguard)** and our [roadmap](https://microsoft.github.io/electionguard/Roadmap). For those looking to get started, we recommend the following repositories.
+ElectionGuard is always improving. To keep up with the latest, check our **[official site on GitHub Pages][5]** and our [roadmap][6]. For those looking to get started, we recommend the following repositories.
 
 ### Documentation
 
-This repository is a living document to help everyone interact with ElectionGuard. The [official ElectionGuard site](https://microsoft.github.io/electionguard) is built using the `/docs` folder and [mkdocs](https://www.mkdocs.org/) with [mkdocs-material](https://squidfunk.github.io/mkdocs-material/). Ensure you have the python 3.8 or newer installed and run `make` to install the dependencies and start the site.
+This repository is a living document to help everyone interact with ElectionGuard. The [official ElectionGuard site][5] is built using the `/docs` folder and [mkdocs][7] with [mkdocs-material][8]. Ensure you have the python 3.8 or newer installed and run `make` to install the dependencies and start the site.
 
 ### Python
 
 A core component of ElectionGuard implemented in python which includes ballot encryption, decryption, key generation, and tallying.
 
-[📁 Source](https://github.com/microsoft/electionguard-python) |
-[📦 Package](https://pypi.org/project/electionguard/) |
-[📝 Documentation](https://microsoft.github.io/electionguard-python/)
+[📁 Source][9] |
+[📦 Package][10] |
+[📝 Documentation][11]
 
 ### C ++
 
 A subset of the ElectionGuard SDK implemented in C++ to support ballot encryption.
 
-[📁 Source](https://github.com/microsoft/electionguard-cpp) |
-[📦 Package](https://www.nuget.org/packages/ElectionGuard.Encryption/) |
-[📝 Documentation](https://github.com/microsoft/electionguard-cpp#readme)
+[📁 Source][12] |
+[📦 Package][13] |
+[📝 Documentation][14]]
 
 ### Web API
 
 A Web API that wraps the python package to perform ballot encryption, casting, spoiling, and tallying.
 
-[📁 Source](https://github.com/microsoft/electionguard-api-python) | [🐳 Docker](https://hub.docker.com/r/electionguard/electionguard-web-api) | [📄 Documentation](https://microsoft.github.io/electionguard-api-python/)
+[📁 Source][15] | 
+[🐳 Docker][16] | 
+[📄 Documentation][17]
 
 ### User Interface
 
 Monorepo in React & Typescript consisting of an api client, components, and apps to demonstrate examples of user interface.
 
-[📁 Source](https://github.com/microsoft/electionguard-ui) | [📄 Documentation](https://github.com/microsoft/electionguard-ui#readme)
+[📁 Source][18] |
+[📄 Documentation][19]
 
 ## 🛡 Security Issues Reporting
 
@@ -55,7 +58,7 @@ Help defend democracy and **[contribute to the project][]**.
 [code of conduct]: CODE_OF_CONDUCT.md
 [contribute to the project]: CONTRIBUTING.md
 
-We welcome discussions on our [discussions page](https://github.com/microsoft/electionguard/discussions), feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
+We welcome discussions on our [discussions page][20], feel free to check in and ask your questions and drop your suggestions regarding the specifications over there.
 
 ## ❓ Questions
 
@@ -65,9 +68,35 @@ ElectionGuard would love for you to ask questions out in the open using Github I
 
 A huge thank you to those who helped to contribute to this project so far, including:
 
-- Josh Benaloh (whose [PhD thesis](https://www.microsoft.com/en-us/research/publication/verifiable-secret-ballot-elections/) was the genesis of much of this work)
-- [InfernoRed Technology](https://infernored.com/)
-- [VotingWorks](https://voting.works/)
-- [Center for Civic Design](https://civicdesign.org/)
-- [Oxide Design](https://oxidedesign.com/)
+- Josh Benaloh (whose [PhD thesis][21] was the genesis of much of this work)
+- [InfernoRed Technology][22]
+- [VotingWorks][23]
+- [Center for Civic Design][24]
+- [Oxide Design][25]
 - Many teams within Microsoft
+
+[1]: docs/images/electionguard-banner.svg "Election Guard banner SVG"
+[2]: https://img.shields.io/github/license/microsoft/electionguard "Election Guard license image"
+[3]: https://blogs.microsoft.com/on-the-issues/?p=63211 "Protecting democratic elections through secure, verifiable voting"
+[4]: https://en.wikipedia.org/wiki/Homomorphic_encryption "Homomorphic encryption"
+[5]: https://microsoft.github.io/electionguard "Official Election Guard site on Github Pages"
+[6]: https://microsoft.github.io/electionguard/Roadmap "Election GUard road map"
+[7]: https://www.mkdocs.org/ "MkDocs official website"
+[8]: https://squidfunk.github.io/mkdocs-material/ "Material for MkDocs"
+[9]: https://github.com/microsoft/electionguard-python "Election Guard Python source code"
+[10]: https://pypi.org/project/electionguard/ "Election Guard Python package"
+[11]: https://microsoft.github.io/electionguard-python/ "Election Guard Python documentation"
+[12]: https://github.com/microsoft/electionguard-cpp/ "Election Guard C++ source code"
+[13]: https://www.nuget.org/packages/ElectionGuard.Encryption/ "Election Guard C++ package"
+[14]: https://github.com/microsoft/electionguard-cpp#readme "Election Guard C++ documentation"
+[15]: https://github.com/microsoft/electionguard-api-python "Election Guard Web API source code"
+[16]: https://hub.docker.com/r/electionguard/electionguard-web-api "Election Guard Web API Docker"
+[17]: https://microsoft.github.io/electionguard-api-python/ "Election Guard Web API documentation"
+[18]: https://github.com/microsoft/electionguard-ui "Election Guard UI source code"
+[19]: https://github.com/microsoft/electionguard-ui#readme "Election Guard UI documentation"
+[20]: https://github.com/microsoft/electionguard/discussions "Election Guard Discussions page"
+[21]: https://www.microsoft.com/en-us/research/publication/verifiable-secret-ballot-elections/ "Verifiable Secret-Ballot Elections - Microsoft Research, Josh Benaloh"
+[22]: https://infernored.com/ "InfernoRed"
+[23]: https://voting.works/ "Voting works - Elections you can trust"
+[24]: https://civicdesign.org/ "Center for civic design"
+[25]: https://oxidedesign.com/ "Oxide Design"


### PR DESCRIPTION
### Linked Issue
Begins to address #101

### Description
Following syntax guidelines for reference-style links in markdown, updates the README to use the new convention. See https://www.markdownguide.org/basic-syntax/#reference-style-links. This allows for more readability of the plaintext document, ease of editing links, and re-usability of links across the doc.

### Testing
Compare against the existing README.md to ensure that all the links point to the same locations, and no functional changes to the rendered page have appeared (besides hover-based labels).
