### PR TITLE
docs: add Introduction WIP message and update links for github issues on contribute page

### DIFF
--- a/docs/basics/Introduction.md
+++ b/docs/basics/Introduction.md
@@ -1,0 +1,4 @@
+# Introduction
+
+!!! warning "Work in Progress"
+    This is a work in progress. Feel free to contribute.

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -21,7 +21,7 @@ The SDK is comprised of five repositories:
 1. Learn about ElectionGuard and share the information
 2. Post questions or ideas in our [**discussion board**][election-guard-discussions]
 3. Join our [**weekly video office hours**][election-guard-weekly-office-hours]
-4. Develop on issues in the repos with tags of **`good first issue`** or **`help wanted`**
+4. Develop on issues in the repos with tags of **[good first issue][github-good-first-issue]** or **[help wanted][github-help-wanted]**
 5. Add to and improve documentation. Keep it Plain English and include [helpful images][undraw-illustrations].
 
 ## Contributions
@@ -52,3 +52,5 @@ ElectionGuard relies on its community for its success. For example, for end-to-e
 [dot-net-verifier]: https://github.com/brandon-irl/electionguard-dotnet "C# Verifier by Brandon Alexander"
 [java-verifier]: https://github.com/JohnLCaron/electionguard-java "Java Verifier by John Caron"
 [python-electionguard-verify]: https://github.com/nickboucher/electionguard-verify "Python Verifier by Nick Boucher"
+[github-good-first-issue]: https://github.com/microsoft/electionguard/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22 "Good first labeled issues on GitHub"
+[github-help-wanted]: https://github.com/microsoft/electionguard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22 "Help wanted labeld issues on GitHub"


### PR DESCRIPTION
### Related issues

Fixes #155 
Fixes #156

### Description

- **add WIP in the Introduction page:**
![image](https://user-images.githubusercontent.com/5417662/137145722-e10095ec-3c3f-468c-aaac-fc7be0e05272.png)

- **update links for GitHub issues:**
![image](https://user-images.githubusercontent.com/5417662/137145840-9791e296-4701-491b-8a1f-90082321078e.png)

----

### Testing
You can run the application, navigate through the `/contribute/` and `/basics/Introduction/` and check if all changes are presente.
