### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A huge thank you to those who helped to contribute to this project so far, inclu
 [election-guard-banner]: docs/images/electionguard-banner.svg "Election Guard banner SVG"
 [license-image]: https://img.shields.io/github/license/microsoft/electionguard "Election Guard license image"
 [build-developer-conference]: https://blogs.microsoft.com/on-the-issues/?p=63211 "Protecting democratic elections through secure, verifiable voting"
-[homomoprhic-encryptio]: https://en.wikipedia.org/wiki/Homomorphic_encryption "Homomorphic encryption"
+[homomoprhic-encryption]: https://en.wikipedia.org/wiki/Homomorphic_encryption "Homomorphic encryption"
 [election-guard-official-page]: https://microsoft.github.io/electionguard "Official Election Guard site on Github Pages"
 [election-guard-road-map]: https://www.electionguard.vote/overview/Roadmap/ "Election Guard road map"
 [mkdocs-official-site]: https://www.mkdocs.org/ "MkDocs official website"


### PR DESCRIPTION
Fixes a typo in the readme that causes the homomoprhic encryption link to display incorrectly

[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
The homomoprhic encryption link doesn't work

Fixes #239

### Description
Fixes a typo in the readme that causes the homomoprhic encryption link to display incorrectly

### Testing
Go onto the github for this branch and look at the readme