### PR TITLE
1️⃣. Ensure Contests and Selections are greater than one in Schema

### DIFF
--- a/data/1.0.0-preview-1/schema/ciphertext_ballot.schema.json
+++ b/data/1.0.0-preview-1/schema/ciphertext_ballot.schema.json
@@ -291,7 +291,7 @@
         "ballot_selections": {
           "title": "Ballot_selections",
           "type": "array",
-          "default": [],
+          "minItems": 1,
           "items": {
             "title": "Items",
             "$ref": "#/definitions/CiphertextBallotSelection"
@@ -361,7 +361,7 @@
       "title": "Contests",
       "description": "List of contests for this ballot",
       "type": "array",
-      "default": [],
+      "minItems": 1,
       "items": {
         "title": "Items",
         "$ref": "#/definitions/CiphertextBallotContest"

--- a/data/1.0.0-preview-1/schema/plaintext_ballot.schema.json
+++ b/data/1.0.0-preview-1/schema/plaintext_ballot.schema.json
@@ -49,7 +49,7 @@
           "title": "Selections",
           "description": "Represents an individual selection on a ballot",
           "type": "array",
-          "default": [],
+          "minItems": 1,
           "items": {
             "title": "Selections",
             "$ref": "#/definitions/PlaintextBallotSelection"

--- a/data/1.0.0-preview-1/schema/submitted_ballot.schema.json
+++ b/data/1.0.0-preview-1/schema/submitted_ballot.schema.json
@@ -300,7 +300,7 @@
         "ballot_selections": {
           "title": "Ballot_selections",
           "type": "array",
-          "default": [],
+          "minItems": 1,
           "items": {
             "title": "Items",
             "$ref": "#/definitions/CiphertextBallotSelection"
@@ -370,7 +370,7 @@
       "title": "Contests",
       "description": "List of contests for this ballot",
       "type": "array",
-      "default": [],
+      "minItems": 1,
       "items": {
         "title": "Items",
         "$ref": "#/definitions/CiphertextBallotContest"


### PR DESCRIPTION
[//]: # (🚨 Please review the CONTRIBUTING.md in this repository. 💔Thank you!)

### Issue
*Link your PR to an issue*

Fixes #263 

### Description
Update schema to ensure contests and selections are above one. Remove the empty `[]` as the default.

### Testing
Can be tested against newer sample data.
