### PR TITLE
Remove label-sync action and update repo names in Makefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,3 @@ jobs:
           name: sample-data
           path: sample-data.zip
           overwrite: true
-      - name: Sync Labels
-        env:
-          GITHUB_ACCESS_TOKEN: ${{ secrets.LABEL_TOKEN }}
-        run: pipenv run make labels

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ deploy:
 # To run this, ensure GITHUB_ACCESS_TOKEN environment variable set
 labels:
 	npm install -g github-label-sync
-	github-label-sync --labels .github/labels.yml microsoft/electionguard
-	github-label-sync --labels .github/labels.yml microsoft/electionguard-cpp
-	github-label-sync --labels .github/labels.yml microsoft/electionguard-python
-	github-label-sync --labels .github/labels.yml microsoft/electionguard-api-python
-	github-label-sync --labels .github/labels.yml microsoft/electionguard-ui
+	github-label-sync --labels .github/labels.yml Election-Tech-Initiative/electionguard
+	github-label-sync --labels .github/labels.yml Election-Tech-Initiative/electionguard-cpp
+	github-label-sync --labels .github/labels.yml Election-Tech-Initiative/electionguard-python
+	github-label-sync --labels .github/labels.yml Election-Tech-Initiative/electionguard-api-python
+	github-label-sync --labels .github/labels.yml Election-Tech-Initiative/electionguard-ui
 
 release-zip-sample-data:
 	@echo 📁 ZIP SAMPLE DATA


### PR DESCRIPTION
### Issue
Fixes #359 

### Description
Removes the label-sync action in the build and changes the repo names in the Makefile to the correct location.

### Testing
Merge PR.