### PR TITLE
Fix polyfill.io reference from insecure site to Cloudflare

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,7 @@ markdown_extensions:
 extra_javascript:
   - javascripts/analytics.js
   - javascripts/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
### Issue
Closes #363

### Description
Removes link to Polyfill.io site and replaces it will Cloudflare mirror

### Testing
None.
